### PR TITLE
Auto-Queue False for consumer repos

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,7 @@ resource "tfe_workspace" "development" {
   name         = "${var.use_case_name}-development"
   organization = "${var.org}"
   auto_apply   = true
+  queue_all_runs = false
 
   vcs_repo = {
     branch         = "development"
@@ -75,6 +76,7 @@ resource "tfe_workspace" "staging" {
   name         = "${var.use_case_name}-staging"
   organization = "${var.org}"
   auto_apply   = true
+  queue_all_runs = false
 
   vcs_repo = {
     branch         = "staging"
@@ -86,6 +88,7 @@ resource "tfe_workspace" "staging" {
 resource "tfe_workspace" "production" {
   name         = "${var.use_case_name}-production"
   organization = "${var.org}"
+  queue_all_runs = false
 
   vcs_repo = {
     branch         = "master"

--- a/sentinel/main.tf
+++ b/sentinel/main.tf
@@ -41,11 +41,7 @@ resource "tfe_policy_set" "global" {
   policy_ids = [
     "${tfe_sentinel_policy.passthrough.id}",
     "${tfe_sentinel_policy.aws-block-allow-all-cidr.id}",
-    "${tfe_sentinel_policy.azurerm-block-allow-all-cidr.id}",
-    "${tfe_sentinel_policy.gcp-block-allow-all-cidr.id}",
     "${tfe_sentinel_policy.aws-restrict-instance-type-default.id}",
-    "${tfe_sentinel_policy.azurerm-restrict-vm-size.id}",
-    "${tfe_sentinel_policy.gcp-restrict-machine-type.id}",
   ]
 }
 
@@ -60,7 +56,7 @@ resource "tfe_policy_set" "production" {
   ]
 
   workspace_external_ids = [
-    "${local.workspaces["ExampleTeam-production"]}",
+    "${local.workspaces["ProfitApp-production"]}",
   ]
 }
 
@@ -75,7 +71,7 @@ resource "tfe_policy_set" "development" {
   ]
 
   workspace_external_ids = [
-    "${local.workspaces["ExampleTeam-development"]}",
+    "${local.workspaces["ProfitApp-development"]}",
   ]
 }
 
@@ -89,7 +85,7 @@ resource "tfe_policy_set" "staging" {
   ]
 
   workspace_external_ids = [
-    "${local.workspaces["ExampleTeam-staging"]}",
+    "${local.workspaces["ProfitApp-staging"]}",
   ]
 }
 


### PR DESCRIPTION
This allows you to create workspaces, and update the needed variables without queueing a plan that will fail due to the initially missing variables in development.

The workflow then changes so you manually queue a plan in development and let it autoapply, and auto-queue no-op plans for staging/production, then you start your CI/CD PR workflow so that the subsequent PR into stage will successfully trigger a plan that shows up in the GitHub UI.

So it's just the first plan that has to be manually queued, then all subsequent PR's/commits will correctly queue plans.

We could maybe add a null exec out to hit the API and do this automatically as a depends on all of the variables.  But it's easy enough to manually queue each one as well.